### PR TITLE
Implement session-based output directories

### DIFF
--- a/analyzer_agent.py
+++ b/analyzer_agent.py
@@ -12,9 +12,9 @@ from pathlib import Path
 from typing import List, Dict, Any
 
 
-def read_poem_files() -> List[Dict[str, Any]]:
-    """Read all poetry files from output directories."""
-    output_dir = Path("output")
+def read_poem_files(session_dir: str = "output") -> List[Dict[str, Any]]:
+    """Read all poetry files from session output directory."""
+    output_dir = Path(session_dir)
     poems = []
 
     if not output_dir.exists():
@@ -197,17 +197,21 @@ def generate_analysis_report(poems: List[Dict[str, Any]]) -> str:
 
 
 def main():
+    import sys
+
+    session_dir = sys.argv[1] if len(sys.argv) > 1 else "output"  # Default for backward compat
+
     print("Analyzer: Starting analysis")
 
-    # Read all poems
-    poems = read_poem_files()
+    # Read all poems from session directory
+    poems = read_poem_files(session_dir)
     print(f"Analyzer: Found {len(poems)} sports to analyze")
 
     # Generate report
     report = generate_analysis_report(poems)
 
-    # Write report
-    output_file = Path("output/analysis_report.md")
+    # Write report to session directory
+    output_file = Path(session_dir) / "analysis_report.md"
     with open(output_file, "w") as f:
         f.write(report)
 

--- a/poetry_agent.py
+++ b/poetry_agent.py
@@ -158,12 +158,13 @@ def main():
         sys.exit(1)
 
     sport = sys.argv[1]
+    session_dir = sys.argv[2] if len(sys.argv) > 2 else "output"  # Default for backward compat
     start_time = time.time()
 
     print(f"Agent {sport}: Starting poetry generation")
 
-    # Create output directory
-    output_dir = Path(f"output/{sport}")
+    # Create output directory within session
+    output_dir = Path(session_dir) / sport
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # Generate haiku


### PR DESCRIPTION
## Summary
Implements session-based output directories to preserve results from multiple workflow runs without overwriting.

Fixes #2

## Changes

### Core Implementation
- **orchestrator.py**: Added `create_session_directory()` method that:
  - Creates `output/{session_id}/` for each run
  - Creates/updates `output/latest` symlink to most recent session
  - Logs session directory creation
  - Passes session directory to all agents

- **poetry_agent.py**: Updated to accept session directory as argument
  - Creates output within session: `{session_dir}/{sport}/`
  - Backward compatible (defaults to "output" if no arg provided)

- **analyzer_agent.py**: Updated to read/write from session directory
  - Reads poems from session directory
  - Writes analysis report to session directory
  - Backward compatible

## New Directory Structure

```
output/
├── demo_001/
│   ├── basketball/
│   ├── soccer/
│   └── analysis_report.md
├── demo_002/
│   ├── ice hockey/
│   └── ...
├── demo_003/
│   ├── football/
│   └── ...
└── latest -> demo_003  # symlink
```

## Usage

**Access latest run:**
```bash
cat output/latest/analysis_report.md
ls output/latest/
```

**Access specific session:**
```bash
cat output/demo_003/basketball/haiku.txt
```

**Compare across sessions:**
```bash
diff output/demo_001/soccer/haiku.txt output/demo_003/soccer/haiku.txt
```

## Testing

✅ Tested with new workflow run (demo_003: football, soccer, basketball)
✅ Session directory created successfully
✅ Symlink created and working
✅ All agents write to correct session directory
✅ Analysis report generated in session directory
✅ No data loss from previous runs

## Benefits

- ✅ Historical comparison - compare results across runs
- ✅ No data loss - never overwrite previous results  
- ✅ Easy access - `latest` symlink always points to newest
- ✅ Debuggable - failed runs preserved for analysis
- ✅ Demo-friendly - show multiple examples side-by-side

## Migration Notes

Existing `output/` files from runs before this PR remain at root level and won't interfere. All future runs will create session directories.

## Future Enhancements

- Add cleanup utility to remove old sessions
- Multi-session analyzer to compare across runs
- Session conflict handling improvements